### PR TITLE
Move license declaration to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,9 @@
 name = "phantom"
 version = "0.0.1"
 authors = ["Jonathan Reem <jonathan.reem@gmail.com>"]
+license = "MIT"
 
-[[lib]]
+[lib]
 
 name = "phantom"
 path = "src/lib.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![license = "MIT"]
 #![deny(missing_docs)]
 #![deny(warnings)]
 


### PR DESCRIPTION
`license` is picked up as an unused attribute and gets rejected by
rustc because of #[deny(warning)]

Also new [lib] block in Cargo.toml
