### PR TITLE
removed license attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![license = "MIT"]
 #![deny(missing_docs)]
 #![deny(warnings)]
 


### PR DESCRIPTION
in rustc 0.13.0-nightly (5484d6f6d 2014-12-02 00:22:00 +0000)

the license tag is causing a build failure:

```
cargo build                                                                                                                                  (git:master)
the [[lib]] section has been deprecated in favor of [lib]
   Compiling phantom v0.0.1 (file:///home/jason/repos/rust-phantom)
src/lib.rs:1:1: 1:20 error: unused attribute, #[deny(unused_attributes)] on by default
src/lib.rs:1 #![license = "MIT"]
             ^~~~~~~~~~~~~~~~~~~
error: aborting due to previous error
Could not compile `phantom`.

To learn more, run the command again with --verbose.
```

additionally, this is causing iron not to compile with 0.13 nightly

I removed the MIT license tag. Problem solved. :)
